### PR TITLE
Refactor some log related codes

### DIFF
--- a/src/main/java/org/lgdcloudsim/core/CloudSim.java
+++ b/src/main/java/org/lgdcloudsim/core/CloudSim.java
@@ -45,6 +45,11 @@ public class CloudSim implements Simulation {
      * The simulation time.
      */
     double clock;
+
+    /**
+     * The simulation time in string format.
+     */
+    String clockStr;
     /**
      * A flag to indicate if the simulation is running or not.
      */
@@ -116,7 +121,7 @@ public class CloudSim implements Simulation {
      * Creates a new CloudSim instance.
      */
     public CloudSim() {
-        clock = 0;
+        setClock(0);
         this.entityList = new ArrayList<>();
         this.future = new FutureQueue();
         this.deferred = new DeferredQueue();
@@ -132,12 +137,13 @@ public class CloudSim implements Simulation {
 
     @Override
     public String clockStr() {
-        return "%.2f ms".formatted(clock);
+        return clockStr;
     }
 
     @Override
     public Simulation setClock(double time) {
         this.clock = time;
+        this.clockStr = "%.2f ms".formatted(clock);
         return this;
     }
 

--- a/src/main/java/org/lgdcloudsim/datacenter/CollaborationManagerSimple.java
+++ b/src/main/java/org/lgdcloudsim/datacenter/CollaborationManagerSimple.java
@@ -106,7 +106,7 @@ public class CollaborationManagerSimple implements CollaborationManager {
         if (datacenter == null) return;
         Set<Integer> collaborationIds = datacenter.getCollaborationIds();
         if (collaborationIds.contains(collaborationId)) {
-            LOGGER.warn("the datacenter(" + datacenter + ") already belongs to the collaboration " + collaborationId);
+            LOGGER.warn("the datacenter({}) already belongs to the collaboration {}", datacenter, collaborationId);
         } else {
             collaborationIds.add(collaborationId);
         }
@@ -163,7 +163,7 @@ public class CollaborationManagerSimple implements CollaborationManager {
         if (datacenter == null) return;
         Set<Integer> collaborationIds = datacenter.getCollaborationIds();
         if (!collaborationIds.contains(collaborationId)) {
-            LOGGER.warn("the datacenter(" + datacenter + ") does not belong to the collaboration " + collaborationId + " to be removed");
+            LOGGER.warn("the datacenter({})'s collaborationIds: {}", datacenter, collaborationIds);
         } else {
             collaborationIds.remove(collaborationId);
         }

--- a/src/main/java/org/lgdcloudsim/record/SqlRecordDetailScheduleTime.java
+++ b/src/main/java/org/lgdcloudsim/record/SqlRecordDetailScheduleTime.java
@@ -168,7 +168,7 @@ public class SqlRecordDetailScheduleTime implements SqlRecord {
         try {
             conn = DriverManager.getConnection("jdbc:sqlite:" + this.dbPath);
             conn.setAutoCommit(false);
-            LOGGER.info("Opened " + this.dbPath + " successfully");
+            LOGGER.info("Opened {} successfully", this.dbPath);
             stmt = conn.createStatement();
 
             createUserRequestTable();
@@ -371,7 +371,7 @@ public class SqlRecordDetailScheduleTime implements SqlRecord {
             stmt.executeUpdate(sql);
         } catch (SQLException e) {
             e.printStackTrace();
-            LOGGER.error("The instance group " + instanceGroup.getId() + " recorded error {}", e.getMessage());
+            LOGGER.error("The instance group {} recorded error {}", instanceGroup.getId(), e.getMessage());
             try {
                 sql = "SELECT * FROM " + this.instanceGroupTableName + " WHERE id = " + instanceGroup.getId() + ";";
                 ResultSet rs = stmt.executeQuery(sql);

--- a/src/main/java/org/lgdcloudsim/record/SqlRecordSimple.java
+++ b/src/main/java/org/lgdcloudsim/record/SqlRecordSimple.java
@@ -148,7 +148,7 @@ public class SqlRecordSimple implements SqlRecord {
         try {
             conn = DriverManager.getConnection("jdbc:sqlite:" + this.dbPath);
             conn.setAutoCommit(false);
-            LOGGER.info("Opened " + this.dbPath + " successfully");
+            LOGGER.info("Opened {} successfully", this.dbPath);
             stmt = conn.createStatement();
 
             createUserRequestTable();


### PR DESCRIPTION
1. Avoid string type concatenation when printing logs.
2. Add the `clockStr` variable to cache the string form of the clock, thus avoiding frequent conversion when printing logs.